### PR TITLE
Fixing import firebase/firestore

### DIFF
--- a/src/firebase/firestore/getData.js
+++ b/src/firebase/firestore/getData.js
@@ -1,5 +1,5 @@
 import firebase_app from "../config";
-import { getFirestore, doc, getDoc } from "firebase/firestore";
+import { getFirestore, doc, getDoc } from "firebase/firestore/lite";
 
 // Get the Firestore instance
 const db = getFirestore(firebase_app);


### PR DESCRIPTION
Had issue where importing geFirestore, doc, getDoc, setDoc from "firebase/firestore" where showing in console that those imports are not being exported from "firebase/firestore" after hours of search i found that this import should be from "firebase/firestore/lite" and i saw that from firebase offical docs