### PR TITLE
Fixing import "firebase/firestore" to "firebase/firestore/lite"

### DIFF
--- a/src/firebase/firestore/addData.ts
+++ b/src/firebase/firestore/addData.ts
@@ -1,5 +1,5 @@
 import firebase_app from "../config";
-import { getFirestore, doc, setDoc } from "firebase/firestore";
+import { getFirestore, doc, setDoc } from "firebase/firestore/lite";
 
 // Get the Firestore instance
 const db = getFirestore(firebase_app);


### PR DESCRIPTION
Had issue where importing geFirestore, doc, getDoc, setDoc from "firebase/firestore" where showing in console that those imports are not being exported from "firebase/firestore" after hours of search i found that this import should be from "firebase/firestore/lite" and i saw that from firebase offical docs